### PR TITLE
Cuisine and brand inference

### DIFF
--- a/src/analysis/analyze_underrated.py
+++ b/src/analysis/analyze_underrated.py
@@ -50,7 +50,12 @@ def main() -> int:
 
     details_path = os.path.join(args.input_dir, f"{args.city_name}_restaurant_details.csv")
     basic_path = os.path.join(args.input_dir, f"{args.city_name}_restaurants.csv")
+    extended_path = os.path.join(args.input_dir, f"{args.city_name}_restaurant_details.extended.csv")
 
+    if os.path.exists(extended_path):
+        print(f"[info] Using extended cuisine file: {extended_path}")
+        details_path = extended_path
+        
     if not os.path.exists(details_path):
         sample_details = os.path.join("data", "sample", "london_restaurant_details.csv")
         if os.path.exists(sample_details):

--- a/src/data_collection/collect_data.py
+++ b/src/data_collection/collect_data.py
@@ -673,7 +673,7 @@ def extend_cuisine_offline(out_path: Optional[pathlib.Path] = None, inplace: boo
             print(f"[info] Backed up original details to {backup}")
         out_file = DETAILS_CSV
     else:
-        out_file = out_path or (OUTDIR / ("london_restaurant_details.extended.csv" if not from_base else "london_restaurant_details.extended_full.csv"))
+        out_file = out_path or (OUTDIR / (f"{CITY_NAME}_restaurant_details.extended.csv" if not from_base else f"{CITY_NAME}_restaurant_details.extended_full.csv"))
         out_file.parent.mkdir(parents=True, exist_ok=True)
 
     with out_file.open("w", newline="", encoding="utf-8") as f:


### PR DESCRIPTION
The `extend_cuisine_offline` function is hardcoded to write to `london_restaurant_details.extended.csv` and not to `CITY_NAME_restaurant_details.extended.csv`.  This changes the code to behave the same as elsewhere.

Further, the `analyse_underrated.py` doesn't reference the `.extended.csv` filename anywhere.  A user **could** rename `london_restaurant_details.extended.csv` to `london_restaurant_details.csv`, but this removes that step by checking for the `.extended.csv` file and using it if it's available.